### PR TITLE
Added copy parameters to enable parallel build

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -64,8 +64,17 @@
         Condition="'%(_ContentRootProjectReferences.Identity)' != ''"
         Include="$([System.IO.Path]::ChangeExtension('%(_ContentRootProjectReferences.ResolvedFrom)', '.deps.json'))" />
     </ItemGroup>
+    
+    <PropertyGroup>
+        <CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+    </PropertyGroup>
 
-    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutDir)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)"
+       DestinationFolder="$(OutDir)"
+       UseHardlinksIfPossible="$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
+       UseSymboliclinksIfPossible="$(CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
+       Condition="Exists('%(DepsFilePaths.FullPath)')" />
   </Target>
 
 </Project>

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -72,8 +72,8 @@
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"
        DestinationFolder="$(OutDir)"
-       UseHardlinksIfPossible="$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
-       UseSymboliclinksIfPossible="$(CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
+       UseHardlinksIfPossible="$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
+       UseSymboliclinksIfPossible="$(_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
        Condition="Exists('%(DepsFilePaths.FullPath)')" />
   </Target>
 

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Added parameters to Copy task that is executed for setting up correct dependency environment in the tests.

**PR Description**
When enabling multiple msbuild nodes it could fail due to locking "xxx.deps.json" files
We have faced with this issue using latest version of microsoft.aspnetcore.mvc.testing nuget package
`C:\ZZZZ\nuget\microsoft.aspnetcore.mvc.testing\5.0.7\build\net5.0\Microsoft.AspNetCore.Mvc.Testing.targets(56, 5): error MSB3027: Unable to copy file "D:\XXXX\bin\Release\YYYY.deps.json" to "bin\Release\YYYY.deps.json". The process cannot access the file 'bin\Release\YYYY.deps.json' because it is being used by another process.`
